### PR TITLE
Depend on only the parts of Silk.NET that we actually use

### DIFF
--- a/magician/Magician.csproj
+++ b/magician/Magician.csproj
@@ -11,6 +11,8 @@
     <Reference Include="SDL2">
       <HintPath>../sdl/SDL2-CS.dll</HintPath>
     </Reference>
-    <PackageReference Include="Silk.NET" Version="2.16.0" />
+    <PackageReference Include="Silk.NET.Core" Version="2.16.0" />
+    <PackageReference Include="Silk.NET.Maths" Version="2.16.0" />
+    <PackageReference Include="Silk.NET.OpenGL" Version="2.16.0" />
   </ItemGroup>
 </Project>

--- a/sdldemo/MagicianDemo.csproj
+++ b/sdldemo/MagicianDemo.csproj
@@ -12,9 +12,6 @@
     <Reference Include="SDL2">
         <HintPath>../sdl/SDL2-CS.dll</HintPath>
     </Reference>
-
-    <PackageReference Include="Silk.NET" Version="2.16.0" />
-
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MagicianTest.csproj
+++ b/tests/MagicianTest.csproj
@@ -12,8 +12,6 @@
     <Reference Include="SDL2">
       <HintPath>sdl/SDL2-CS.dll</HintPath>
     </Reference>
-
-    <PackageReference Include="Silk.NET" Version="2.16.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />


### PR DESCRIPTION
Silk.NET is a pretty modular package, and the Silk.NET package pulls in at least the following:

- Silk.NET.Core
- Silk.NET.GLFW
- Silk.NET.Input
- Silk.NET.OpenAL
- Silk.NET.OpenGL
- Silk.NET.Vulkan
- Silk.NET.Vulkan.Extensions.KHR
- Silk.NET.Windowing

We actually use SDL-CS.dll for all SDL interactions, so all we need are the core library, OpenGL bindings and math utilities.